### PR TITLE
Use boto session to avoid multithreading error

### DIFF
--- a/django_ses_boto3/ses_email_backend.py
+++ b/django_ses_boto3/ses_email_backend.py
@@ -69,7 +69,6 @@ class SESEmailBackend(BaseEmailBackend):
             return False
         return True
 
-
     @staticmethod
     def get_boto_session():
         session = getattr(local_storage, 'session', None)

--- a/django_ses_boto3/ses_email_backend.py
+++ b/django_ses_boto3/ses_email_backend.py
@@ -9,6 +9,7 @@ from django.core.mail.message import sanitize_address
 
 local_storage = threading.local()
 
+
 class SESEmailBackend(BaseEmailBackend):
     def __init__(self, *args, **kwargs):
         super(SESEmailBackend, self).__init__(*args, **kwargs)
@@ -76,3 +77,4 @@ class SESEmailBackend(BaseEmailBackend):
             session = boto3.Session()
             local_storage.session = session
         return session
+


### PR DESCRIPTION
Use boto session instead of directly call `client` to avoid multithreading error.